### PR TITLE
Concurrency fixes

### DIFF
--- a/site/main.js
+++ b/site/main.js
@@ -1,7 +1,8 @@
 let c;
 let ctx;
 
-const ws = new WebSocket("wss://race-game-go.herokuapp.com/ws")
+// const ws = new WebSocket("wss://race-game-go.herokuapp.com/ws")
+const ws = new WebSocket('ws://localhost:3000/ws'); 
 let version = '0.1.1'
 
 class Box {


### PR DESCRIPTION
Gorilla WebSocket doesn't guard against concurrent writes: protected against that by placing writes in their own goroutine.  Also, there was a race condition: what if two players (in two concurrent connections) both try to change the "currentBoxes" variable?  Only one goroutine can execute inside a locked mutex at a time.  Desiderata: use channels to send win state notifications.  